### PR TITLE
update to compile on nightly.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,6 @@
 name = "spatial"
 version = "0.0.1"
 authors = ["Eeli Reilin <eeli@fea.st>"]
+
+[dependencies]
+num = "0.1.24"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,23 +53,25 @@ pub mod quadtree;
 pub mod octree;
 
 extern crate core;
-use core::num::Float;
+extern crate num;
+use num::traits::Float;
+use num::NumCast;
 use core::ops::Add;
+use core::ops::Sub;
+use core::ops::Mul;
 use core::ops::Div;
 use std::fmt::Display;
 
-pub trait SpatialKey : Float + Display + PartialOrd + Add<Self, Output=Self> + Div<Self, Output=Self> + Copy {
-	fn div2(&self) -> Self;
-}
+pub trait SpatialKey : Float 
+		+ Display 
+		+ PartialOrd 
+		+ Add<Self, Output=Self> 
+		+ Sub<Self, Output=Self> 
+		+ Mul<Self, Output=Self> 
+		+ Div<Self, Output=Self> 
+		+ NumCast
+		+ Copy {}
 
-impl SpatialKey for f32 {
-	fn div2(&self) -> f32 {
-		self/2f32
-	}
-}
+impl SpatialKey for f32 {}
 
-impl SpatialKey for f64 {
-	fn div2(&self) -> f64 {
-		self/2f64
-	}
-}
+impl SpatialKey for f64 {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,9 +45,31 @@
 #![feature(box_syntax)]
 #![feature(collections)]
 #![feature(core)]
+#![feature(convert)]
 
 pub use quadtree::Quadtree;
 pub use octree::Octree;
-
 pub mod quadtree;
 pub mod octree;
+
+extern crate core;
+use core::num::Float;
+use core::ops::Add;
+use core::ops::Div;
+use std::fmt::Display;
+
+pub trait SpatialKey : Float + Display + PartialOrd + Add<Self, Output=Self> + Div<Self, Output=Self> + Copy {
+	fn div2(&self) -> Self;
+}
+
+impl SpatialKey for f32 {
+	fn div2(&self) -> f32 {
+		self/2f32
+	}
+}
+
+impl SpatialKey for f64 {
+	fn div2(&self) -> f64 {
+		self/2f64
+	}
+}

--- a/src/octree/volume.rs
+++ b/src/octree/volume.rs
@@ -1,16 +1,16 @@
-use std::fmt::Display;
+use SpatialKey;
 use std::fmt;
-use std::num::Float;
+use std::fmt::Display;
 
 /// A three-dimensional bounding volume for an `Octree` node.
-pub struct Volume<T: Float> {
+pub struct Volume<T: SpatialKey> {
     /// The upper-top-left corner.
     pub min: [T; 3],
     /// The lower-bottom-right corner.
     pub max: [T; 3]
 }
 
-impl<T: Float> Volume<T> {
+impl<T: SpatialKey> Volume<T> {
     /// Create a new bounding volume from three points, where both `min`
     /// and `max` are of format `[x, y, z]`.
     #[inline]
@@ -56,7 +56,7 @@ impl<T: Float> Volume<T> {
     }
 }
 
-impl<T: Float + Display> Display for Volume<T> {
+impl<T: SpatialKey> Display for Volume<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let min = self.min;
         let max = self.max;

--- a/src/quadtree/mod.rs
+++ b/src/quadtree/mod.rs
@@ -1,6 +1,4 @@
-use std::num::{Float, NumCast};
-use std::ops::Div;
-use std::fmt::Display;
+use SpatialKey;
 pub use self::volume::Volume;
 
 mod volume;
@@ -10,13 +8,13 @@ static DEFAULT_CAPACITY: usize = 8;
 
 /// A trait that must be implemented by types that are going to be
 /// inserted into a `Quadtree`.
-pub trait Index<T: Float + Display> {
+pub trait Index<T: SpatialKey> {
     /// This method returns the position for `self` in 2D-space. The
     /// return format should be in order of `[x, y]`.
     fn quadtree_index(&self) -> [T; 2];
 }
 
-pub struct Quadtree<T: Float + Display, P: Index<T> + Clone> {
+pub struct Quadtree<T: SpatialKey, P: Index<T> + Clone> {
     /// Maximum number of items to store before subdivision.
     capacity: usize,
     /// Items in this quadtree node.
@@ -27,7 +25,7 @@ pub struct Quadtree<T: Float + Display, P: Index<T> + Clone> {
     quadrants: Option<[Box<Quadtree<T, P>>; 4]>
 }
 
-impl<T: Float + Display, P: Index<T> + Clone> Quadtree<T, P> {
+impl<T: SpatialKey, P: Index<T> + Clone> Quadtree<T, P> {
     /// Constructs a new, empty `Quadtree` with bounding volume `vol`
     /// and default node capacity of `DEFAULT_CAPACITY`.
     #[inline]
@@ -124,7 +122,7 @@ impl<T: Float + Display, P: Index<T> + Clone> Quadtree<T, P> {
     fn subdivide(&mut self) {
         let min = self.volume.min;
         let max = self.volume.max;
-        let (hw, hh) = (half(max[0]), half(max[1]));
+        let (hw, hh) = (max[0].div2(), max[1].div2());
         
         self.quadrants = Some([
             box Quadtree::with_capacity(Volume::new([min[0], min[1]], [hw, hh]), self.capacity),
@@ -133,9 +131,4 @@ impl<T: Float + Display, P: Index<T> + Clone> Quadtree<T, P> {
             box Quadtree::with_capacity(Volume::new([min[0] + hw, min[1] + hh], [max[0], max[1]]), self.capacity)
                 ]);
     }
-}
-
-#[inline]
-fn half<T: Float + Display>(n: T) -> T {
-    n.div(NumCast::from(2).unwrap())
 }

--- a/src/quadtree/volume.rs
+++ b/src/quadtree/volume.rs
@@ -1,16 +1,16 @@
-use std::fmt::Display;
+use SpatialKey;
 use std::fmt;
-use std::num::Float;
+use std::fmt::Display;
 
 /// A two-dimensional bounding volume for a `Quadtree` node.
-pub struct Volume<T: Float> {
+pub struct Volume<T: SpatialKey> {
     /// The upper-left corner.
     pub min: [T; 2],
     /// The lower-right corner.
     pub max: [T; 2]
 }
 
-impl<T: Float> Volume<T> {
+impl<T: SpatialKey> Volume<T> {
     /// Create a new bounding volume from two points, where both `min`
     /// and `max` are of format `[x, y]`.
     #[inline]
@@ -54,7 +54,7 @@ impl<T: Float> Volume<T> {
     }
 }
 
-impl<T: Float + Display> Display for Volume<T> {
+impl<T: SpatialKey> Display for Volume<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let min = self.min;
         let max = self.max;

--- a/tests/octree.rs
+++ b/tests/octree.rs
@@ -49,5 +49,9 @@ fn octree_insert_query() {
     assert_eq!(tree.get_in_volume(&Volume::new([0.0, 0.5, 0.5], [0.5, 1.0, 1.0])).len(), 1);
     assert_eq!(tree.get_in_volume(&Volume::new([0.5, 0.5, 0.5], [1.0, 1.0, 1.0])).len(), 1);
     
+    assert_eq!(tree.get_in_radius([0.5, 0.5, 0.5], 0f32).len(), 0);
+    assert_eq!(tree.get_in_radius([0.25, 0.25, 0.25], 0.25).len(), 1);
+    assert_eq!(tree.get_in_radius([0.5, 0.5, 0.5], 0.5).len(), 8);
+    
     assert_eq!(tree.len(), 8);
 }

--- a/tests/quadtree.rs
+++ b/tests/quadtree.rs
@@ -39,5 +39,9 @@ fn quadtree_insert_query() {
     assert_eq!(tree.get_in_volume(&Volume::new([0.0, 0.5], [0.5, 1.0])).len(), 1);
     assert_eq!(tree.get_in_volume(&Volume::new([0.5, 0.5], [1.0, 1.0])).len(), 1);
     
+    assert_eq!(tree.get_in_radius([0.5, 0.5], 0f32).len(), 0);
+    assert_eq!(tree.get_in_radius([0.25, 0.25], 0.25).len(), 1);
+    assert_eq!(tree.get_in_radius([0.5, 0.5], 0.5).len(), 4);
+    
     assert_eq!(tree.len(), 4);
 }


### PR DESCRIPTION
This change updates the library to compile on nightly, which failed due to a few problems:
- NumCast doesn't exist
- Float trait does not have default implementations for (Ord + Add + Div)

I created a new SpatialKey trait and impls for f32 and f64.  The change cleans up the code a bit, and is compatible with nightly, but also comes with a downside.  Float trait implementations must also implement SpatialKey to be compatible with spatial.  The Spatial lib would need to be updated if one is added to the Rust core, and users of spatial that define custom Float implementations would need to define a SpatialKey implementation.